### PR TITLE
Fix MaxBuffer size limit so that you can now unzip up to 1 GBG files

### DIFF
--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -86,16 +86,21 @@ function execute(type: Type, command: Command, archive: string, options: Options
 
     switch (type) {
         case Type.Asynchronous:
-            return child_process.exec(fullCommand, { encoding: 'buffer' }, callback);
+            return child_process.exec(fullCommand, { encoding: 'buffer', maxBuffer: 1073741823 }, callback);
         case Type.Synchronous:
-            return child_process.execSync(fullCommand);
+            return child_process.execSync(fullCommand, { encoding: 'buffer', maxBuffer: 1073741823 });
         case Type.Promise:
-            return new Promise((resolve, reject) => {
-                child_process.exec(fullCommand, { encoding: 'buffer' }, (error, stdout, stderr) => {
+            return new Promise(function(resolve, reject) {
+                // 1073741823 is the current max Buffer size allowed in Node, equals 1gb
+                child_process.exec(fullCommand, { encoding: 'buffer', maxBuffer: 1073741823 }, function(
+                    error,
+                    stdout,
+                    stderr
+                ) {
                     if (error) {
                         reject(error);
                     } else {
-                        resolve(<Result>{ stdout, stderr });
+                        resolve({ stdout: stdout, stderr: stderr });
                     }
                 });
             });


### PR DESCRIPTION
This will fix it for up to unzip up to 1 GBG files, which I think is fine to start with.
I would like to re-write this to utilise the below, but couldnt figure out how to correctly detect the end of the file unzip process:
'use strict';
const { spawn, exec } = require('child_process');

var bufferResult = null;
// I dont think full command is correct here
// ""c:\CLS\VSTS\Remote\Remote\node_modules\7zip-bin\win\x64\7za.exe" e "C:\RemotePackage-2018-08-29T00_42_33.1193321Z.zip" "remote.json" -p"GFR4F57CYDLVCUEZ" -so -y"
var command = 'cmd';
var args = [ 
	'"c:\\CLS\\VSTS\\Remote\\Remote\\node_modules\\7zip-bin\\win\\x64\\7za.exe"',
	'e',
	'"C:\\RemotePackage-2018-08-29T00_42_33.1193321Z.zip"', 
	'"remote.json"', 
	'-p',
	'"GFR4F57CYDLVCUEZ"',
	'-so',
	'-y'
];


console.log(args);

const streamProcess = spawn(command, args);
streamProcess.stdout.on('data', function(data){
	try {
		console.log('stdout: ' + data.toString());
		console.log(data);
		// What do we do with a stream?
		var tempBuffer = null;
		if(Buffer.isBuffer(data)){
			console.log('Is a buffer object');
			console.log('length is:' + Buffer.byteLength(data));
			tempBuffer = data;
		} else {
			console.log('Is NOT a buffer object');
			tempBuffer = Buffer.from(data);
		}
		 
		if(bufferResult){
			
			bufferResult = Buffer.concat([bufferResult, tempBuffer]);
		} else {
			// may need [] around data
			bufferResult = tempBuffer;
		}
	} catch (err) {
		console.log('An Error Ocurred');
		console.log(err);
	}
});

streamProcess.stderr.on('data', function (data) {
  console.log('stderr: ' + data.toString());
});

streamProcess.on('exit', function (code) {
  console.log('child process exited with code ' + code.toString());
});

streamProcess.on('end', function (code) {
  console.log('child process end with code ' + code.toString());
});

streamProcess.on('close', function (code) {
  console.log('child process close with code ' + code.toString());
});