### PR TITLE
fix adding files to archive

### DIFF
--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -80,7 +80,7 @@ function execute(type: Type, command: Command, archive: string, options: Options
         throw new Error(`Cannot find file "${archive}"`);
     }
 
-    const files = options.files ? options.files.map(file => `"${file}"`) : '';
+    const files = options.files ? options.files.map(file => `"${file}"`).join(' ') : '';
     const parsedArguments = parseOptions(options);
     const fullCommand = `"${baseCommand}" ${command} "${archive}" ${files} ${parsedArguments} -y`;
     // 1073741823 is the current max Buffer size allowed in Node, equals 1gb


### PR DESCRIPTION
Using the following command:

```
this.sevenzip.addPromise('zipLocationAndFileName', { files: ['C:\ProgramData\1.txt', 'C:\ProgramData\2.txt'] })
```

Results in the following error:

```
Error: Command failed: "exe location" a "zipLocationAndFileName" "C:\ProgramData\1.txt","C:\ProgramData\2.txt""  -y

WARNING: The filename, directory name, or volume label syntax is incorrect.
C:\ProgramData\1.txt,C:\ProgramData\2.txt
```

7Zip needs file names separated by spaces not commas.